### PR TITLE
hide floating window when Xcode goes to the background

### DIFF
--- a/XToDo/XToDoWindowController.m
+++ b/XToDo/XToDoWindowController.m
@@ -110,6 +110,7 @@
     [self.workingIndicator setHidden:YES];
 
     self.window.level = NSFloatingWindowLevel;
+	self.window.hidesOnDeactivate = YES;
     self.data = [NSMutableDictionary dictionaryWithCapacity:5];
 
     NSUserDefaults* prefs = [NSUserDefaults standardUserDefaults];


### PR DESCRIPTION
For your consideration, a change to hide the To Do window on deactivate so it doesn't float over other application's windows when Xcode is in the background.
