### PR TITLE
Xcode 6.3.2, 6.4b2 compatibility

### DIFF
--- a/XToDo/XToDo-Info.plist
+++ b/XToDo/XToDo-Info.plist
@@ -32,6 +32,7 @@
 		<string>A16FF353-8441-459E-A50C-B071F53F51B7</string>
 		<string>9F75337B-21B4-4ADC-B558-F9CADF7073A7</string>
 		<string>8DC44374-2B35-4C57-A6FE-2AD66A36AAD9</string>
+		<string>E969541F-E6F9-4D25-8158-72DC3545A6C6</string>
 	</array>
 	<key>XC4Compatible</key>
 	<true/>

--- a/XToDo/XToDo-Info.plist
+++ b/XToDo/XToDo-Info.plist
@@ -31,6 +31,7 @@
 		<string>C4A681B0-4A26-480E-93EC-1218098B9AA0</string>
 		<string>A16FF353-8441-459E-A50C-B071F53F51B7</string>
 		<string>9F75337B-21B4-4ADC-B558-F9CADF7073A7</string>
+		<string>8DC44374-2B35-4C57-A6FE-2AD66A36AAD9</string>
 	</array>
 	<key>XC4Compatible</key>
 	<true/>

--- a/XToDo/XToDo.m
+++ b/XToDo/XToDo.m
@@ -14,6 +14,10 @@ XToDo* sharedPlugin = nil;
 
 @interface XToDo ()
 @property (nonatomic, strong) XToDoWindowController* windowController;
+
+- (void)applicationDidFinishLaunching:(NSNotification *)notification;
+- (void)addMenuItems;
+
 @end
 
 @implementation XToDo
@@ -35,72 +39,88 @@ XToDo* sharedPlugin = nil;
     self = [super init];
     if (self) {
         self.bundle = plugin;
-
-        //insert a menuItem to MainMenu "Window"
-        NSMenuItem* menuItem = [[NSApp mainMenu] itemWithTitle:@"View"];
-        if (menuItem) {
-            [[menuItem submenu] addItem:[NSMenuItem separatorItem]];
-
-            NSMenuItem* actionMenuItem = [[NSMenuItem alloc] initWithTitle:@"ToDo List"
-                                                                    action:@selector(toggleList)
-                                                             keyEquivalent:@"t"];
-
-            [actionMenuItem setKeyEquivalentModifierMask:NSControlKeyMask];
-
-            [actionMenuItem setTarget:self];
-            [[menuItem submenu] addItem:actionMenuItem];
-
-            //add Snippet Group
-            NSMenu* submenu = [[NSMenu alloc] init];
-
-            NSMenuItem* mainItem = [[NSMenuItem alloc] init];
-            [mainItem setTitle:@"Snippets"];
-
-            [mainItem setSubmenu:submenu];
-            [[menuItem submenu] addItem:mainItem];
-
-            //support snippets to add TODO
-            actionMenuItem = [[NSMenuItem alloc] initWithTitle:@"TODO"
-                                                        action:@selector(insertToDo)
-                                                 keyEquivalent:@"t"];
-
-            [actionMenuItem setKeyEquivalentModifierMask:NSControlKeyMask | NSShiftKeyMask];
-
-            [actionMenuItem setTarget:self];
-            [submenu addItem:actionMenuItem];
-
-            //support snippets to add FIXME
-            actionMenuItem = [[NSMenuItem alloc] initWithTitle:@"FIXME"
-                                                        action:@selector(insertFixMe)
-                                                 keyEquivalent:@"x"];
-
-            [actionMenuItem setKeyEquivalentModifierMask:NSControlKeyMask | NSShiftKeyMask];
-
-            [actionMenuItem setTarget:self];
-            [submenu addItem:actionMenuItem];
-
-            //support snippets to add !!!
-            actionMenuItem = [[NSMenuItem alloc] initWithTitle:@"!!!"
-                                                        action:@selector(insertWarn)
-                                                 keyEquivalent:@"1"];
-
-            [actionMenuItem setKeyEquivalentModifierMask:NSControlKeyMask | NSShiftKeyMask];
-
-            [actionMenuItem setTarget:self];
-            [submenu addItem:actionMenuItem];
-
-            //support snippets to add ???
-            actionMenuItem = [[NSMenuItem alloc] initWithTitle:@"???"
-                                                        action:@selector(insertAsk)
-                                                 keyEquivalent:@"q"];
-
-            [actionMenuItem setKeyEquivalentModifierMask:NSControlKeyMask | NSShiftKeyMask];
-
-            [actionMenuItem setTarget:self];
-            [submenu addItem:actionMenuItem];
-        }
+        [[NSNotificationCenter defaultCenter] addObserver:self
+                                                 selector:@selector(applicationDidFinishLaunching:)
+                                                     name:NSApplicationDidFinishLaunchingNotification
+                                                   object:nil];
     }
     return self;
+}
+
+
+- (void)applicationDidFinishLaunching:(NSNotification *)notification {
+    [self addMenuItems];
+    [[NSNotificationCenter defaultCenter] removeObserver:self
+                                                    name:NSApplicationDidFinishLaunchingNotification
+                                                  object:nil];
+}
+
+- (void)addMenuItems {
+    // insert a menuItem to MainMenu "Window"
+    NSMenuItem* menuItem = [[NSApp mainMenu] itemWithTitle:@"View"];
+    if (!menuItem) {
+        return;
+    }
+    
+    [[menuItem submenu] addItem:[NSMenuItem separatorItem]];
+    
+    NSMenuItem* actionMenuItem = [[NSMenuItem alloc] initWithTitle:@"ToDo List"
+                                                            action:@selector(toggleList)
+                                                     keyEquivalent:@"t"];
+    
+    [actionMenuItem setKeyEquivalentModifierMask:NSControlKeyMask];
+    
+    [actionMenuItem setTarget:self];
+    [[menuItem submenu] addItem:actionMenuItem];
+    
+    //add Snippet Group
+    NSMenu* submenu = [[NSMenu alloc] init];
+    
+    NSMenuItem* mainItem = [[NSMenuItem alloc] init];
+    [mainItem setTitle:@"Snippets"];
+    
+    [mainItem setSubmenu:submenu];
+    [[menuItem submenu] addItem:mainItem];
+    
+    //support snippets to add TODO
+    actionMenuItem = [[NSMenuItem alloc] initWithTitle:@"TODO"
+                                                action:@selector(insertToDo)
+                                         keyEquivalent:@"t"];
+    
+    [actionMenuItem setKeyEquivalentModifierMask:NSControlKeyMask | NSShiftKeyMask];
+    
+    [actionMenuItem setTarget:self];
+    [submenu addItem:actionMenuItem];
+    
+    //support snippets to add FIXME
+    actionMenuItem = [[NSMenuItem alloc] initWithTitle:@"FIXME"
+                                                action:@selector(insertFixMe)
+                                         keyEquivalent:@"x"];
+    
+    [actionMenuItem setKeyEquivalentModifierMask:NSControlKeyMask | NSShiftKeyMask];
+    
+    [actionMenuItem setTarget:self];
+    [submenu addItem:actionMenuItem];
+    
+    //support snippets to add !!!
+    actionMenuItem = [[NSMenuItem alloc] initWithTitle:@"!!!"
+                                                action:@selector(insertWarn)
+                                         keyEquivalent:@"1"];
+    
+    [actionMenuItem setKeyEquivalentModifierMask:NSControlKeyMask | NSShiftKeyMask];
+    
+    [actionMenuItem setTarget:self];
+    [submenu addItem:actionMenuItem];
+    
+    //support snippets to add ???
+    actionMenuItem = [[NSMenuItem alloc] initWithTitle:@"???"
+                                                action:@selector(insertAsk)
+                                         keyEquivalent:@"q"];
+    
+    [actionMenuItem setKeyEquivalentModifierMask:NSControlKeyMask | NSShiftKeyMask];
+    
+    [actionMenuItem setTarget:self];
+    [submenu addItem:actionMenuItem];
 }
 
 - (BOOL)validateMenuItem:(NSMenuItem*)menuItem


### PR DESCRIPTION
Xcode 6.4 changed the run-point for when it loads plugins; instead of after the application finished launching, it now happens in something more like `applicationWillFinishLaunching`, and at that point in time, the `[NSApp mainMenu]` object is still `nil`. In order to get around this, the app must listen for the `NSApplicationDidFinishLaunchingNotification` notification, and fire any code that interacts with `[NSApp mainMenu]` then.

Since 6.3.2 also just came out, I've added the UUID for that, too. The fix for 6.4b2 is backwards compatible as well.