### PR TITLE
Add Carthage to Default Excluded Paths

### DIFF
--- a/XToDo/ProjectSetting.m
+++ b/XToDo/ProjectSetting.m
@@ -31,7 +31,7 @@
 {
     ProjectSetting* projectSetting = [[ProjectSetting alloc] init];
     projectSetting.includeDirs = @[ [XToDoModel rootPathMacro] ];
-    projectSetting.excludeDirs = @[ [XToDoModel addPathSlash:[[XToDoModel rootPathMacro] stringByAppendingPathComponent:@"Pods"]] ];
+    projectSetting.excludeDirs = @[ [XToDoModel addPathSlash:[[XToDoModel rootPathMacro] stringByAppendingPathComponent:@"Pods"]], [XToDoModel addPathSlash:[[XToDoModel rootPathMacro] stringByAppendingPathComponent:@"Carthage"]] ];
     return projectSetting;
 }
 


### PR DESCRIPTION
[Carthage](https://github.com/Carthage/Carthage) is another popular dependency manager besides CocoaPods. This PR will make XToDo ignore Carthage dependencies by default.